### PR TITLE
asplib_CPUTimer.h: Fix time.h include

### DIFF
--- a/asplib_modules/Timer/asplib/Timer/asplib_CPUTimer.h
+++ b/asplib_modules/Timer/asplib/Timer/asplib_CPUTimer.h
@@ -29,7 +29,7 @@
   #include <windows.h>
   #include <time.h>
 #elif defined(TARGET_LINUX)
-  #include <sys/time.h>
+  #include <time.h>
 #endif
 
 namespace asplib


### PR DESCRIPTION
According to https://linux.die.net/man/3/clock_gettime time.h needs to
be included instead of sys/time.h.

This patch fixes a build error found by buildroot autobuilders:

http://autobuild.buildroot.net/results/cc0/cc0b928ee24a526b7c82fd3f391e2be024a14578//

/home/peko/autobuild/instance-1/output/build/libasplib-be7fac89218a84b75f7598e3d76625ece99296f2/asplib_modules/Timer/asplib/Timer/asplib_CPUTimer.cpp: In member function 'void asplib::CCPUTimer::start_Timer()':
/home/peko/autobuild/instance-1/output/build/libasplib-be7fac89218a84b75f7598e3d76625ece99296f2/asplib_modules/Timer/asplib/Timer/asplib_CPUTimer.cpp:69:19: error: 'CLOCK_REALTIME' was not declared in this scope
     clock_gettime(CLOCK_REALTIME, &m_startTime);